### PR TITLE
* Base query update, no longer using json.dumps

### DIFF
--- a/src/senaite/samplepointlocations/extenders/utils.py
+++ b/src/senaite/samplepointlocations/extenders/utils.py
@@ -21,7 +21,7 @@ class ClientAwareReferenceWidget(ReferenceWidget):
 
         # portal_type: use field allowed types
         field = context.Schema().getField(fieldName)
-        allowed_types = getattr(field, "allowed_types", None)
+        allowed_types = getattr(field, "allowed_types", [])
         allowed_types_method = getattr(field, "allowed_types_method", None)
         if allowed_types_method:
             meth = getattr(context, allowed_types_method)
@@ -42,7 +42,7 @@ class ClientAwareReferenceWidget(ReferenceWidget):
                 base_query["getParentUID"] = [client_uid]
             else:
                 base_query["getClientUID"] = [client_uid, ""]
-        return json.dumps(base_query)
+        return base_query
 
 
 registerWidget(ClientAwareReferenceWidget, title="Client aware Reference Widget")


### PR DESCRIPTION
Issue: [LIMS-575](https://bika.atlassian.net/browse/LIMS-575)
**Before:**
The base_query is a string instead of a dict thus the update method can not be applied leading to the attribute error.

**After:**
* Base query update, no longer using json.dumps
-- json.dumps will make a dict into a string thus creating the attribute error above
* If no allowed_types an empty list is now returned instead of None
-- This was done so that we can iterate through the allowed types value which is a list. If no allowed_types an empty list is returned which can still be iterated.

[LIMS-575]: https://bika.atlassian.net/browse/LIMS-575?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ